### PR TITLE
Thresholds for red and yellow traffic changes

### DIFF
--- a/MMM-Traffic.js
+++ b/MMM-Traffic.js
@@ -76,9 +76,9 @@ Module.register('MMM-Traffic', {
 
         //change color if desired and append
         if (this.config.changeColor) {
-          if (this.trafficComparison >= 1.5) {
+          if (this.trafficComparison >= 1 + (this.config.limitRed / 100)) {
             commuteInfo.className += ' red';
-          } else if (this.trafficComparison >= 1.2) {
+          } else if (this.trafficComparison >= 1 + (this.config.limitYellow / 100)) {
             commuteInfo.className += ' yellow';
           } else if (this.config.showGreen) {
             commuteInfo.className += ' green';

--- a/MMM-Traffic.js
+++ b/MMM-Traffic.js
@@ -20,6 +20,8 @@ Module.register('MMM-Traffic', {
         loadingText: 'Loading commute...',
         prependText: 'Current commute is',
         changeColor: false,
+        limitYellow: 20,
+        limitRed: 50,
         showGreen: true,
         language: config.language,
         show_summary: true

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Here is an example of an entry in `config.js`
 		route_name: 'Home to Work',
 		changeColor: true,
 		showGreen: false,
+		limitYellow: 5, //Greater than 5% of journey time due to traffic
+		limitRed: 20, //Greater than 20% of journey time due to traffic
 		traffic_model: 'pessimistic',
 		interval: 120000 //2 minutes
 	}

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ If you would like the commute info to change to yellow and red based on traffic 
 changeColor: true,
 showGreen: false
 ```
+Thresholds for Yellow and Red are set with the percentage traffic as a whole number. Defaults are yellow = 20%, red = 50%
+```
+limitYellow: 20,
+limitRed: 50
+```
+
 Update interval in milliseconds, default is 300000 (5 minutes)
 ```
 interval: 120000 //2 minutes

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you would like the commute info to change to yellow and red based on traffic 
 changeColor: true,
 showGreen: false
 ```
-Thresholds for Yellow and Red are set with the percentage traffic as a whole number. Defaults are yellow = 20%, red = 50%
+The thresholds for yellow and red can be set to the percentage traffic time as a whole number. Defaults are yellow = 20%, red = 50%
 ```
 limitYellow: 20,
 limitRed: 50

--- a/README.md
+++ b/README.md
@@ -35,21 +35,17 @@ What kind of traffic estimate you want, default is 'best_guess'. Can also be 'op
 ```
 traffic_model: 'optimistic'
 ```
-When `changeColor` is set to true, the color of the commute info will change based on traffic. If traffic increases the commute by 20%, the symbol and commute text will be yellow. An increase of 50% will change the color to red. If the traffic doesn't increase the commute by at least 20%, the color will be green. The default value for `changeColor` is false, leaving the symbol/text white.
+When `changeColor` is set to true, the color of the commute info will change based on traffic. If traffic increases the commute by `limitYellow`, the symbol and commute text will be yellow. An increase of `limitRed` will change the color to red. If the traffic doesn't increase the commute by at least `limitYellow`, the color will be green. The default value for `changeColor` is false, leaving the symbol/text white. The thresholds for yellow and red can be set to the percentage traffic time as a whole number. Defaults are yellow = 20%, red = 50%
 ```
-changeColor: true
+changeColor: true,
+limitYellow: 20,
+limitRed: 50
 ```
 If you would like the commute info to change to yellow and red based on traffic but otherwise remain white, set `changeColor` to true and `showGreen` to false, like so:
 ```
 changeColor: true,
 showGreen: false
 ```
-The thresholds for yellow and red can be set to the percentage traffic time as a whole number. Defaults are yellow = 20%, red = 50%
-```
-limitYellow: 20,
-limitRed: 50,
-```
-
 Update interval in milliseconds, default is 300000 (5 minutes)
 ```
 interval: 120000 //2 minutes

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ showGreen: false
 The thresholds for yellow and red can be set to the percentage traffic time as a whole number. Defaults are yellow = 20%, red = 50%
 ```
 limitYellow: 20,
-limitRed: 50
+limitRed: 50,
 ```
 
 Update interval in milliseconds, default is 300000 (5 minutes)


### PR DESCRIPTION
Implements `limitRed' and `limitYellow' config variables to set threshold for color change