### PR TITLE
Allowing for different destinations on different weekdays

### DIFF
--- a/MMM-Traffic.js
+++ b/MMM-Traffic.js
@@ -154,7 +154,7 @@ Module.register('MMM-Traffic', {
         var params = '?';
         params += 'mode=' + this.config.mode;
         params += '&origin=' + this.config.origin;
-        params += '&destination=' + getTodaysDestination();
+        params += '&destination=' + this.getTodaysDestination();
         params += '&key=' + this.config.api_key;
         params += '&traffic_model=' + this.config.traffic_model;
         params += '&language=' + this.config.language;
@@ -188,7 +188,7 @@ Module.register('MMM-Traffic', {
             break;
         }
 
-        if(todays_destination == ""){ //if no weekday destinations defined in config.js, set to default
+        if(todays_destination === ""){ //if no weekday destinations defined in config.js, set to default
             todays_destination = this.config.destination;           
         }
 

--- a/MMM-Traffic.js
+++ b/MMM-Traffic.js
@@ -14,7 +14,12 @@ Module.register('MMM-Traffic', {
         mode: 'driving',
         interval: 300000, //all modules use milliseconds
         origin: '',
-        destination: '',
+        defaultDestination: '',
+        mon_destination: '',
+        tues_destination: '',
+        wed_destination: '',
+        thurs_destination: '',
+        fri_destination: '',
         traffic_model: 'best_guess',
         departure_time: 'now',
         arrival_time: '',
@@ -149,7 +154,30 @@ Module.register('MMM-Traffic', {
         var params = '?';
         params += 'mode=' + this.config.mode;
         params += '&origin=' + this.config.origin;
-        params += '&destination=' + this.config.destination;
+        
+        var destination = ""
+        switch (new Date().getDay()) {
+          case 1:
+            destination = this.config.mon_destination;
+            break;
+          case 2:
+            destination = this.config.tues_destination;
+            break;
+          case 3:
+            destination = this.config.wed_destination; 
+            break;
+          case 4:
+            destination = this.config.thurs_destination;
+            break;
+          case 5:
+            destination = this.config.fri_destination;
+            break;
+          default:
+            //to handle Sat and Sun. GoogleAPI may raise error if no destination set       
+            destination = this.config.defaultDestination; 
+            break;
+        }
+        params += '&destination=' + destination;
         params += '&key=' + this.config.api_key;
         params += '&traffic_model=' + this.config.traffic_model;
         params += '&language=' + this.config.language;

--- a/MMM-Traffic.js
+++ b/MMM-Traffic.js
@@ -14,7 +14,7 @@ Module.register('MMM-Traffic', {
         mode: 'driving',
         interval: 300000, //all modules use milliseconds
         origin: '',
-        defaultDestination: '',
+        destination: '',
         mon_destination: '',
         tues_destination: '',
         wed_destination: '',
@@ -154,30 +154,7 @@ Module.register('MMM-Traffic', {
         var params = '?';
         params += 'mode=' + this.config.mode;
         params += '&origin=' + this.config.origin;
-        
-        var destination = ""
-        switch (new Date().getDay()) {
-          case 1:
-            destination = this.config.mon_destination;
-            break;
-          case 2:
-            destination = this.config.tues_destination;
-            break;
-          case 3:
-            destination = this.config.wed_destination; 
-            break;
-          case 4:
-            destination = this.config.thurs_destination;
-            break;
-          case 5:
-            destination = this.config.fri_destination;
-            break;
-          default:
-            //to handle Sat and Sun. GoogleAPI may raise error if no destination set       
-            destination = this.config.defaultDestination; 
-            break;
-        }
-        params += '&destination=' + destination;
+        params += '&destination=' + getTodaysDestination();
         params += '&key=' + this.config.api_key;
         params += '&traffic_model=' + this.config.traffic_model;
         params += '&language=' + this.config.language;
@@ -185,6 +162,37 @@ Module.register('MMM-Traffic', {
           params += '&avoid=' + this.config.avoid;
         }
         return params;
+    },
+
+    getTodaysDestination: function() {
+        var todays_destination = "";
+        switch (new Date().getDay()) {
+          case 1:
+            todays_destination = this.config.mon_destination;
+            break;
+          case 2:
+            todays_destination = this.config.tues_destination;
+            break;
+          case 3:
+            todays_destination = this.config.wed_destination; 
+            break;
+          case 4:
+            todays_destination = this.config.thurs_destination;
+            break;
+          case 5:
+            todays_destination = this.config.fri_destination;
+            break;
+          default:
+            //to handle Sat and Sun (GoogleAPI may raise error if no destination set)   
+            todays_destination = this.config.destination; 
+            break;
+        }
+
+        if(todays_destination == ""){ //if no weekday destinations defined in config.js, set to default
+            todays_destination = this.config.destination;           
+        }
+
+        return todays_destination;
     },
 
     socketNotificationReceived: function(notification, payload) {

--- a/MMM-Traffic.js
+++ b/MMM-Traffic.js
@@ -185,7 +185,6 @@ Module.register('MMM-Traffic', {
           default:
             //to handle Sat and Sun (GoogleAPI may raise error if no destination set)   
             todays_destination = this.config.destination; 
-            break;
         }
 
         if(todays_destination === ""){ //if no weekday destinations defined in config.js, set to default

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The entry in `config.js` can include the following options:
 |`api_key`|The API key, which can be obtained [here](https://developers.google.com/maps/documentation/directions/).<br><br>**Type:** `string`<br>This value is **REQUIRED**|
 |`origin`|The start location as the address or name of a location.<br>**Example:** `'Yankee Stadium'` or `'500 Main Street New York NY'`<br><br>This value is **REQUIRED**|
 |`destination`|The end location as the address or name of a location.<br>**Example:** `'PNC Arena'` or `'1000 Main Street New York NY'`<br><br>This value is **REQUIRED**|
+|`mon_destination`|If you want to specify a different destination for every Monday, use this. This Option exists for all of the other weekdays as well: `tues_destination`, `wed_destination`, `thurs_destination`, `fri_destination`<br><br>**Example:** `'PNC Arena'` or `'1000 Main Street New York NY'`
 |`arrival_time`|If you want the module to give you a departure time, put a 24 hour formatted time that you would like to arrive.<br>**Example:** `'1445'`|
 |`mode`|Mode of transportation.<br><br>**Default value:** `'driving'`<br>**Other Options:**`'walking' 'bicycling' 'transit'`|
 |`avoid`|Set to 'tolls','highways', or 'ferries' to avoid them in the route<br><br>**Default value:** None|
@@ -48,6 +49,8 @@ Here is an example of an entry in `config.js`
 		mode: 'driving',
 		origin: '4 Pennsylvania Plaza, New York, NY 10001',
 		destination: '1 MetLife Stadium Dr, East Rutherford, NJ 07073',
+		mon_destination: '116th St & Broadway, New York, NY 10027',
+		fri_destination: '1 E 161st St, Bronx, NY 10451',
 		arrival_time: '0800', //optional, but needs to be in 24 hour time if used.
 		route_name: 'Home to Work',
 		changeColor: true,


### PR DESCRIPTION
Provides the feature requested by @darrenelmslie (#31) 

Users will be able to specify different weekday destinations in config.js. The change is backwards compatible - if no destinations for weekdays are specified, it will default to using config.destination.